### PR TITLE
feature proposal: Code Blocks and Inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ You can submit your RSS file to a public website, or put it somewhere easily ava
 
 ### TODO
 List of features that are on the planning. Feel free to send suggestions here.
- * Display source code from markdown more correctly.
  * For non textual RSS readers: render images.
 
 ### Why RSS?

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -1,125 +1,209 @@
 package lib
 
 import (
-  "bufio"
-  "errors"
-  "os"
-  "regexp"
-  "strconv"
-  "strings"
-  "unicode"
+	"bufio"
+	"errors"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
 )
 
 var markdownUlListActive bool
 var markdownOlIndex int64
+var codeBlockAggregate, codeBlockOpen = "", false
 
 func checkMarkdownTitle(text string) bool {
-  if len(text) > 0 {
-    return string(text[0]) == string("#")
-  }
-  return false
+	if len(text) > 0 {
+		return string(text[0]) == string("#")
+	}
+	return false
 }
 
 func getLeadingWhitespace(text string) int {
-  for index, letter := range text {
-    if unicode.IsLetter(letter) {
-      return index
-    }
-  }
-  return 0
+	for index, letter := range text {
+		if unicode.IsLetter(letter) {
+			return index
+		}
+	}
+	return 0
 }
 
 func convertMarkdownLink(text string, markdownLinks *regexp.Regexp) string {
-  return "<p>" + markdownLinks.ReplaceAllString(text, "<a href='$2'>$1</a>") + "</p>"
+	return "<p>" + markdownLinks.ReplaceAllString(text, "<a href='$2'>$1</a>") + "</p>"
 }
 
 func convertMarkdownEnclosure(text string, markdownLinks *regexp.Regexp) string {
-  url := markdownLinks.ReplaceAllString(text, "$2")
-  size, fileSizeErr := FileSizeUrl(url)
-  if fileSizeErr != nil {
-    Error.Println(fileSizeErr)
-    return ""
-  }
-  return "<enclosure " + markdownLinks.ReplaceAllString(text, "url='$2' type='$1' length='") + size + "' />"
+	url := markdownLinks.ReplaceAllString(text, "$2")
+	size, fileSizeErr := FileSizeUrl(url)
+	if fileSizeErr != nil {
+		Error.Println(fileSizeErr)
+		return ""
+	}
+	return "<enclosure " + markdownLinks.ReplaceAllString(text, "url='$2' type='$1' length='") + size + "' />"
 }
 
 func convertMarkdownUlList(text string) string {
-  if !markdownUlListActive {
-    markdownUlListActive = true
-    return "<ul><li>" + text[getLeadingWhitespace(text):] + "</li>"
-  }
-  return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
+	if !markdownUlListActive {
+		markdownUlListActive = true
+		return "<ul><li>" + text[getLeadingWhitespace(text):] + "</li>"
+	}
+	return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
 }
 
 func convertMarkdownOlList(text string, index int64) string {
-  if markdownOlIndex == 0 {
-    markdownOlIndex = 1
-    return "<ol><li>" + text[getLeadingWhitespace(text):] + "</li>"
-  }
-  return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
+	if markdownOlIndex == 0 {
+		markdownOlIndex = 1
+		return "<ol><li>" + text[getLeadingWhitespace(text):] + "</li>"
+	}
+	return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
 }
 
 func ConvertMarkdownToRSS(text string) string {
-  markdownLinks := regexp.MustCompile(`\[(.*)\]\((.*)\)`)
-  markdownUnorderedLists := regexp.MustCompile(`^(\s*)(-|\*|\+)[\s](.*)`)
-  markdownOrderedLists := regexp.MustCompile(`^(\s*)(-?\d+)(\.\s+)(.*)$`)
-  if markdownLinks.Match([]byte(text)) && strings.Contains(text, "audio/mpeg") {
-    return convertMarkdownEnclosure(text, markdownLinks)
-  }
-  if markdownLinks.Match([]byte(text)) {
-    return convertMarkdownLink(text, markdownLinks)
-  }
-  if markdownUnorderedLists.Match([]byte(text)) {
-    return convertMarkdownUlList(text)
-  } else if markdownUlListActive {
-    markdownUlListActive = false
-    return "</ul><p>" + text + "</p>"
-  }
-  if markdownOrderedLists.Match([]byte(text)) {
-    entryIndex, entryErr := strconv.ParseInt(markdownOrderedLists.FindStringSubmatch(text)[2], 10, 64)
-    entryText := markdownOrderedLists.FindStringSubmatch(text)[4]
-    if entryErr != nil {
-      return "<p>" + text + "</p>"
-    }
-    return convertMarkdownOlList(entryText, entryIndex)
-  } else if markdownOlIndex != 0 {
-    markdownOlIndex = 0
-    return "</ol><p>" + text + "</p>"
-  }
-  return "<p>" + text + "</p>"
+	markdownLinks := regexp.MustCompile(`\[(.*)\]\((.*)\)`)
+	markdownUnorderedLists := regexp.MustCompile(`^(\s*)(-|\*|\+)[\s](.*)`)
+	markdownOrderedLists := regexp.MustCompile(`^(\s*)(-?\d+)(\.\s+)(.*)$`)
+	fencedCodeBlock := regexp.MustCompile("^```")
+
+	// We don't want to format inside of a codeblock, so return early
+	if codeBlockOpen && !fencedCodeBlock.MatchString(text) {
+		if codeBlockAggregate != "" {
+			codeBlockAggregate += "<br>"
+		}
+		codeBlockAggregate += text
+		return ""
+	}
+
+	if markdownLinks.Match([]byte(text)) && strings.Contains(text, "audio/mpeg") {
+		return convertMarkdownEnclosure(text, markdownLinks)
+	}
+	if markdownLinks.Match([]byte(text)) {
+		return convertMarkdownLink(text, markdownLinks)
+	}
+
+	if markdownUnorderedLists.Match([]byte(text)) {
+		return convertMarkdownUlList(text)
+	} else if markdownUlListActive {
+		markdownUlListActive = false
+		return "</ul><p>" + text + "</p>"
+	}
+
+	if markdownOrderedLists.Match([]byte(text)) {
+		entryIndex, entryErr := strconv.ParseInt(markdownOrderedLists.FindStringSubmatch(text)[2], 10, 64)
+		entryText := markdownOrderedLists.FindStringSubmatch(text)[4]
+		if entryErr != nil {
+			return "<p>" + text + "</p>"
+		}
+		return convertMarkdownOlList(entryText, entryIndex)
+	} else if markdownOlIndex != 0 {
+		markdownOlIndex = 0
+		return "</ol><p>" + ConvertMarkdownToRSS(text)
+	}
+
+	if fencedCodeBlock.Match([]byte(text)) {
+		if !codeBlockOpen {
+			codeBlockOpen = true
+			codeBlockAggregate = ""
+			// Language specifier, if it exists
+			if len(text) > 3 {
+				codeBlockAggregate = "<sup>" + text[3:] + "</sup><br>"
+			}
+			return "" + "<pre><code>"
+		} else {
+			out := codeBlockAggregate
+			codeBlockAggregate, codeBlockOpen = "", false
+			return out + "</code></pre>"
+		}
+	}
+
+	return "<p>" + text + "</p>"
+
+	/* // Same code as above, written as a switch statement, makes more sense to me personally
+
+	switch {
+	// We don't want to format inside of a codeblock, so return early
+	case codeBlockOpen && !fencedCodeBlock.MatchString(text):
+		if codeBlockAggregate != "" {
+			codeBlockAggregate += "<br>"
+		}
+		codeBlockAggregate += text
+		return ""
+
+	case markdownLinks.MatchString(text):
+		if strings.Contains(text, "audio/mpeg") {
+			return convertMarkdownEnclosure(text, markdownLinks)
+		} else {
+			return convertMarkdownLink(text, markdownLinks)
+		}
+
+	case markdownUnorderedLists.MatchString(text):
+		return convertMarkdownUlList(text)
+
+	case markdownUlListActive:
+		markdownUlListActive = false
+		return "</ul><p>" + text + "</p>"
+
+	case markdownOrderedLists.MatchString(text):
+		entryIndex, entryErr := strconv.ParseInt(markdownOrderedLists.FindStringSubmatch(text)[2], 10, 64)
+		entryText := markdownOrderedLists.FindStringSubmatch(text)[4]
+		if entryErr != nil {
+			return "<p>" + text + "</p>"
+		}
+		return convertMarkdownOlList(entryText, entryIndex)
+
+	case markdownOlIndex != 0:
+		markdownOlIndex = 0
+		return "</ol>" + ConvertMarkdownToRSS(text)
+
+	case fencedCodeBlock.MatchString(text):
+		if !codeBlockOpen {
+			codeBlockOpen = true
+			codeBlockAggregate = "<sup>" + text[3:] + "</sup><br>"
+			return "" + "<pre style=\"word-wrap: break-word;\"><code>"
+		} else {
+			out := codeBlockAggregate
+			codeBlockAggregate, codeBlockOpen = "", false
+			return out + "</code></pre>"
+		}
+
+	default:
+		return "<p>" + text + "</p>"
+	}
+	*/
 }
 
 func GetArticles(config Config) ([]Article, error) {
-  RawArticles, fileErr := os.ReadDir(config.InputFolder)
-  articles := []Article{}
-  if fileErr == nil {
-    for _, file := range RawArticles {
-      if !file.IsDir() && !strings.HasPrefix(file.Name(), "draft-") && strings.HasSuffix(file.Name(), ".md") {
-        var article Article
-        fileInfo, _ := file.Info()
-        article.Filename = file.Name()
-        article.DatePublished = fileInfo.ModTime()
-        articles = append(articles, article)
-      }
-    }
-    return articles, nil
-  }
-  return articles, errors.New("Error when getting files from input directory.")
+	RawArticles, fileErr := os.ReadDir(config.InputFolder)
+	articles := []Article{}
+	if fileErr == nil {
+		for _, file := range RawArticles {
+			if !file.IsDir() && !strings.HasPrefix(file.Name(), "draft-") && strings.HasSuffix(file.Name(), ".md") {
+				var article Article
+				fileInfo, _ := file.Info()
+				article.Filename = file.Name()
+				article.DatePublished = fileInfo.ModTime()
+				articles = append(articles, article)
+			}
+		}
+		return articles, nil
+	}
+	return articles, errors.New("Error when getting files from input directory.")
 }
 
 func ReadMarkdown(config Config, articles []Article) []Article {
-  for index := range articles {
-    markdownUlListActive = false
-    filePath := config.InputFolder + "/" + articles[index].Filename
-    readFile, _ := os.Open(filePath)
-    scanner := bufio.NewScanner(readFile)
-    for scanner.Scan() {
-      if checkMarkdownTitle(scanner.Text()) && len(articles[index].Title) == 0 {
-        articles[index].Title = scanner.Text()[2:len(scanner.Text())]
-      } else if len(scanner.Text()) > 0 {
-        articles[index].Description += ConvertMarkdownToRSS(scanner.Text())
-      }
-    }
-  }
-  return articles
+	for index := range articles {
+		markdownUlListActive = false
+		filePath := config.InputFolder + "/" + articles[index].Filename
+		readFile, _ := os.Open(filePath)
+		scanner := bufio.NewScanner(readFile)
+		for scanner.Scan() {
+			if checkMarkdownTitle(scanner.Text()) && len(articles[index].Title) == 0 {
+				articles[index].Title = scanner.Text()[2:len(scanner.Text())]
+			} else if len(scanner.Text()) > 0 || codeBlockOpen {
+				articles[index].Description += ConvertMarkdownToRSS(scanner.Text())
+			}
+		}
+	}
+	return articles
 }

--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -110,11 +110,11 @@ func ConvertMarkdownToRSS(text string) string {
 			if len(text) > 3 {
 				codeBlockAggregate = "<sup>" + text[3:] + "</sup><br>"
 			}
-			return "" + "<pre><code>"
+			return "" + "<pre>"
 		} else {
 			out := codeBlockAggregate
 			codeBlockAggregate, codeBlockOpen = "", false
-			return out + "</code></pre>"
+			return out + "</pre>"
 		}
 	}
 	if inlineCodeBlock.Match([]byte(text)) {

--- a/test/another-article.md
+++ b/test/another-article.md
@@ -36,6 +36,8 @@ fencedCodeBlock := regexp.MustCompile("^```")
 	  // Show off your tabwidth in style!
 ```
 
+This feature also works `inline` as well!
+
 And back to text again
 
 

--- a/test/another-article.md
+++ b/test/another-article.md
@@ -25,9 +25,16 @@ And this is another (ordered) list:
 1. howdy
 2. 1 + 1 = ...
 4. out of order?
-5. back on track
-3. suprise!
--9. oh
+5. doesn't matter!
+
+Codeblocks:
+```go
+// The regex that captures this codeblock:
+fencedCodeBlock := regexp.MustCompile("^```")
+
+	// Code blocks keep original formatting, whitespace is important!
+	  // Show off your tabwidth in style!
+```
 
 And back to text again
 


### PR DESCRIPTION
Wraps a fenced code block in html's \<pre> and \<code> tags. \<pre> is a requirement, as it keeps whitespace which is important in code readability, however the \<code> tag only seems to render/apply correctly on some RSS renderers, so may not be needed. Inline blocks however, are *only* wrapped in \<code> tags.

Also with the addition of this, the if statements in the main parsing function, ```ConvertMarkdownToRSS``` were getting cumbersome so I extracted the logic (as a comment for easy removal) to a switch statement for possibly better readability.

Tried changing the formatter to format to single-space indentations but i guess it didn't work, sorry again!
![image](https://github.com/user-attachments/assets/249dfd98-31ae-4acb-a93f-0ba40b3b5887)
![image](https://github.com/user-attachments/assets/22cd4f22-af23-4b93-afc3-47364ba221a6)
