### PR TITLE
Feature proposal: inline formatting

### DIFF
--- a/lib/markdown.go
+++ b/lib/markdown.go
@@ -1,13 +1,13 @@
 package lib
 
 import (
-  "bufio"
-  "errors"
-  "os"
-  "regexp"
-  "strconv"
-  "strings"
-  "unicode"
+	"bufio"
+	"errors"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
 )
 
 var markdownUlListActive bool
@@ -15,137 +15,159 @@ var markdownOlIndex int64
 var codeBlockAggregate, codeBlockOpen = "", false
 
 func checkMarkdownTitle(text string) bool {
-  if len(text) > 0 {
-    return string(text[0]) == string("#")
-  }
-  return false
+	if len(text) > 0 {
+		return string(text[0]) == string("#")
+	}
+	return false
 }
 
 func getLeadingWhitespace(text string) int {
-  for index, letter := range text {
-    if unicode.IsLetter(letter) {
-      return index
-    }
-  }
-  return 0
+	for index, letter := range text {
+		if unicode.IsLetter(letter) {
+			return index
+		}
+	}
+	return 0
 }
 
 func convertMarkdownLink(text string, markdownLinks *regexp.Regexp) string {
-  return "<p>" + markdownLinks.ReplaceAllString(text, "<a href='$2'>$1</a>") + "</p>"
+	return "<p>" + markdownLinks.ReplaceAllString(text, "<a href='$2'>$1</a>") + "</p>"
 }
 
 func convertMarkdownEnclosure(text string, markdownLinks *regexp.Regexp) string {
-  url := markdownLinks.ReplaceAllString(text, "$2")
-  size, fileSizeErr := FileSizeUrl(url)
-  if fileSizeErr != nil {
-    Error.Println(fileSizeErr)
-    return ""
-  }
-  return "<enclosure " + markdownLinks.ReplaceAllString(text, "url='$2' type='$1' length='") + size + "' />"
+	url := markdownLinks.ReplaceAllString(text, "$2")
+	size, fileSizeErr := FileSizeUrl(url)
+	if fileSizeErr != nil {
+		Error.Println(fileSizeErr)
+		return ""
+	}
+	return "<enclosure " + markdownLinks.ReplaceAllString(text, "url='$2' type='$1' length='") + size + "' />"
 }
 
 func convertMarkdownUlList(text string) string {
-  if !markdownUlListActive {
-    markdownUlListActive = true
-    return "<ul><li>" + text[getLeadingWhitespace(text):] + "</li>"
-  }
-  return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
+	if !markdownUlListActive {
+		markdownUlListActive = true
+		return "<ul><li>" + text[getLeadingWhitespace(text):] + "</li>"
+	}
+	return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
 }
 
 func convertMarkdownOlList(text string, index int64) string {
-  if markdownOlIndex == 0 {
-    markdownOlIndex = 1
-    return "<ol><li>" + text[getLeadingWhitespace(text):] + "</li>"
-  }
-  return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
+	if markdownOlIndex == 0 {
+		markdownOlIndex = 1
+		return "<ol><li>" + text[getLeadingWhitespace(text):] + "</li>"
+	}
+	return "<li>" + text[getLeadingWhitespace(text):] + "</li>"
 }
 
 func ConvertMarkdownToRSS(text string) string {
-  markdownLinks := regexp.MustCompile(`\[(.*)\]\((.*)\)`)
-  markdownUnorderedLists := regexp.MustCompile(`^(\s*)(-|\*|\+)[\s](.*)`)
-  markdownOrderedLists := regexp.MustCompile(`^(\s*)(-?\d+)(\.\s+)(.*)$`)
-  fencedCodeBlock := regexp.MustCompile("^\x60\x60\x60")
-  inlineCodeBlock := regexp.MustCompile(`([\x60]+)([^\x60]+)([\x60]+)`)
+	markdownLinks := regexp.MustCompile(`\[(.*)\]\((.*)\)`)
+	markdownUnorderedLists := regexp.MustCompile(`^(\s*)(-|\*|\+)[\s](.*)`)
+	markdownOrderedLists := regexp.MustCompile(`^(\s*)(-?\d+)(\.\s+)(.*)$`)
+	fencedCodeBlock := regexp.MustCompile("^\x60\x60\x60")
 
-  switch {
-    case codeBlockOpen && !fencedCodeBlock.MatchString(text):
-      if codeBlockAggregate != "" {
-        codeBlockAggregate += "<br>"
-      }
-      codeBlockAggregate += text
-      return ""
-    case markdownLinks.MatchString(text):
-      if strings.Contains(text, "audio/mpeg") {
-        return convertMarkdownEnclosure(text, markdownLinks)
-      } else {
-        return convertMarkdownLink(text, markdownLinks)
-      }
-    case markdownUnorderedLists.MatchString(text):
-      return convertMarkdownUlList(text)
-    case markdownUlListActive:
-      markdownUlListActive = false
-      return "</ul><p>" + text + "</p>"
-    case markdownOrderedLists.MatchString(text):
-      entryIndex, entryErr := strconv.ParseInt(markdownOrderedLists.FindStringSubmatch(text)[2], 10, 64)
-      entryText := markdownOrderedLists.FindStringSubmatch(text)[4]
-      if entryErr != nil {
-        return "<p>" + text + "</p>"
-      }
-      return convertMarkdownOlList(entryText, entryIndex)
-    case markdownOlIndex != 0:
-      markdownOlIndex = 0
-      return "</ol>" + ConvertMarkdownToRSS(text)
-    case fencedCodeBlock.MatchString(text):
-      if !codeBlockOpen {
-        codeBlockOpen = true
-        codeBlockAggregate = "<sup>" + text[3:] + "</sup><br>"
-        return "" + "<pre style=\"word-wrap: break-word;\"><code>"
-      } else {
-        out := codeBlockAggregate
-        codeBlockAggregate, codeBlockOpen = "", false
-        return out + "</code></pre>"
-      }
-    case inlineCodeBlock.Match([]byte(text)):
-      out := inlineCodeBlock.ReplaceAllFunc([]byte(text), func(b []byte) []byte {
-        return []byte("<code>" + inlineCodeBlock.FindStringSubmatch(string(b))[2] + "</code>")
-      })
-      return string(out)
-    default:
-      return "<p>" + text + "</p>"
-  }
+	// Strikethrough
+	text = inlineRewrap(text, regexp.MustCompile(`(~~)([^~~]+)(~~)`), "<s>", "</s>")
+	// Subscript
+	text = inlineRewrap(text, regexp.MustCompile(`(~)([^~]+)(~)`), "<sub>", "</sub>")
+	// Superscript
+	text = inlineRewrap(text, regexp.MustCompile(`(\^)([^\^]+)(\^)`), "<sup>", "</sup>")
+
+	// Strong Emphasis
+	text = inlineRewrap(text, regexp.MustCompile(`(\*\*\*|___)([^\*^_]+)(\*\*\*|___)`), "<b><i>", "</b></i>")
+	// Bold
+	text = inlineRewrap(text, regexp.MustCompile(`(\*\*|__)([^\*^_]+)(\*\*|__)`), "<b>", "</b>")
+	// Italic
+	text = inlineRewrap(text, regexp.MustCompile(`(\*|_)([^\*^_]+)(\*|_)`), "<i>", "</i>")
+
+	// Inline Codeblock
+	text = inlineRewrap(text, regexp.MustCompile(`(\x60)([^\x60]+)(\x60)`), "<code>", "</code>")
+
+	switch {
+	case codeBlockOpen && !fencedCodeBlock.MatchString(text):
+		if codeBlockAggregate != "" {
+			codeBlockAggregate += "<br>"
+		}
+		codeBlockAggregate += text
+		return ""
+	case markdownLinks.MatchString(text):
+		if strings.Contains(text, "audio/mpeg") {
+			return convertMarkdownEnclosure(text, markdownLinks)
+		} else {
+			return convertMarkdownLink(text, markdownLinks)
+		}
+	case markdownUnorderedLists.MatchString(text):
+		return convertMarkdownUlList(text)
+	case markdownUlListActive:
+		markdownUlListActive = false
+		return "</ul><p>" + text + "</p>"
+	case markdownOrderedLists.MatchString(text):
+		entryIndex, entryErr := strconv.ParseInt(markdownOrderedLists.FindStringSubmatch(text)[2], 10, 64)
+		entryText := markdownOrderedLists.FindStringSubmatch(text)[4]
+		if entryErr != nil {
+			return "<p>" + text + "</p>"
+		}
+		return convertMarkdownOlList(entryText, entryIndex)
+	case markdownOlIndex != 0:
+		markdownOlIndex = 0
+		return "</ol>" + ConvertMarkdownToRSS(text)
+	case fencedCodeBlock.MatchString(text):
+		if !codeBlockOpen {
+			codeBlockOpen = true
+			codeBlockAggregate = "<sup>" + text[3:] + "</sup><br>"
+			return "" + "<pre style=\"word-wrap: break-word;\"><code>"
+		} else {
+			out := codeBlockAggregate
+			codeBlockAggregate, codeBlockOpen = "", false
+			return out + "</code></pre>"
+		}
+	default:
+		return "<p>" + text + "</p>"
+	}
+}
+
+func inlineRewrap(text string, pattern *regexp.Regexp, prefix string, postfix string) string {
+	if pattern.Match([]byte(text)) {
+		out := pattern.ReplaceAllFunc([]byte(text), func(b []byte) []byte {
+			return []byte(prefix + pattern.FindStringSubmatch(string(b))[2] + postfix)
+		})
+		return string(out)
+	} else {
+		return text
+	}
 }
 
 func GetArticles(config Config) ([]Article, error) {
-  RawArticles, fileErr := os.ReadDir(config.InputFolder)
-  articles := []Article{}
-  if fileErr == nil {
-    for _, file := range RawArticles {
-      if !file.IsDir() && !strings.HasPrefix(file.Name(), "draft-") && strings.HasSuffix(file.Name(), ".md") {
-        var article Article
-        fileInfo, _ := file.Info()
-        article.Filename = file.Name()
-        article.DatePublished = fileInfo.ModTime()
-        articles = append(articles, article)
-      }
-    }
-    return articles, nil
-  }
-  return articles, errors.New("Error when getting files from input directory.")
+	RawArticles, fileErr := os.ReadDir(config.InputFolder)
+	articles := []Article{}
+	if fileErr == nil {
+		for _, file := range RawArticles {
+			if !file.IsDir() && !strings.HasPrefix(file.Name(), "draft-") && strings.HasSuffix(file.Name(), ".md") {
+				var article Article
+				fileInfo, _ := file.Info()
+				article.Filename = file.Name()
+				article.DatePublished = fileInfo.ModTime()
+				articles = append(articles, article)
+			}
+		}
+		return articles, nil
+	}
+	return articles, errors.New("Error when getting files from input directory.")
 }
 
 func ReadMarkdown(config Config, articles []Article) []Article {
-  for index := range articles {
-    markdownUlListActive = false
-    filePath := config.InputFolder + "/" + articles[index].Filename
-    readFile, _ := os.Open(filePath)
-    scanner := bufio.NewScanner(readFile)
-    for scanner.Scan() {
-      if checkMarkdownTitle(scanner.Text()) && len(articles[index].Title) == 0 {
-        articles[index].Title = scanner.Text()[2:len(scanner.Text())]
-      } else if len(scanner.Text()) > 0 || codeBlockOpen {
-        articles[index].Description += ConvertMarkdownToRSS(scanner.Text())
-      }
-    }
-  }
-  return articles
+	for index := range articles {
+		markdownUlListActive = false
+		filePath := config.InputFolder + "/" + articles[index].Filename
+		readFile, _ := os.Open(filePath)
+		scanner := bufio.NewScanner(readFile)
+		for scanner.Scan() {
+			if checkMarkdownTitle(scanner.Text()) && len(articles[index].Title) == 0 {
+				articles[index].Title = scanner.Text()[2:len(scanner.Text())]
+			} else if len(scanner.Text()) > 0 || codeBlockOpen {
+				articles[index].Description += ConvertMarkdownToRSS(scanner.Text())
+			}
+		}
+	}
+	return articles
 }

--- a/test/another-article.md
+++ b/test/another-article.md
@@ -13,7 +13,14 @@ Timo
 
 And here goes some text...
 
-[link](https://timokats.xyz)
+**bold** text, __however you like it__.
+*italic* too? _Of course_!
+Sometimes ***strong emphasis*** is needed to get across a ___point___.
+~~You can always striketrough a bad idea~~,
+Make something unique with a ~subscript~,
+Or power up with a ^superscript^!
+
+A [link](https://timokats.xyz)
 
 And this is a list:
 - hello
@@ -68,5 +75,3 @@ int main() {
 This feature also works `inline` as well!
 
 And back to text again
-
-


### PR DESCRIPTION
It is my understanding that primarily text based RSS readers like Newsboat strip html tags that they cannot render, so I thought preserving styling information for the RSS readers that do handle them would create a better end user experience. As for spacing, i have no idea why it is not working, my config in VSC is 2 space indents, so sorry for a third time 🥲. 
![image](https://github.com/user-attachments/assets/34d3981e-b2f8-49ab-a601-839d762f72dc)
![image](https://github.com/user-attachments/assets/aa2a90d3-0d94-404e-b819-0ddfde9bec07)
![image](https://github.com/user-attachments/assets/7d14f800-12b0-4127-9f91-1e36447d7994)
