### PR TITLE
Feature Proposal(s): Extended configuration options & Interactive Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,33 @@
 MDRSS is a markdown to RSS converter written in GO. With this tool, you can write articles in a local folder and have them automatically formatted to an RSS compliant XML file. As a result, you don't have to write articles on your website first and have them be read by an RSS reader. Moreover, MDRSS automatically takes care of publication dates, categories (next update), formatting, etc.
 
 ### Getting started
-You can install the binary using `go install github.com/TimoKats/mdrss@latest` (make sure your GOPATH is set correctly!). After this you can add your configuration in `~/.mdrss/config.json`. This is a JSON file with a number of settings. You can use this template to setup your configuration.
+You can install the binary using `go install github.com/TimoKats/mdrss@latest` (make sure your GOPATH is set correctly!). After this you can run `mdrss init`, which interactively prompts you for crucial information regarding your new feed. It also scaffolds most other optional elements from the RSS 2.0 Specification for high customizability, like a custom feed image!
 
 ```JSON
   {
-    "Author": "Timo Kats",
-    "Description": "Timo's weblog",
-    "InputFolder": "/path/to/articles/", # This will contain your markdown files
-    "OutputFile": "/path/to/webserver/index.xml",
-    "Link": "index.xml" # can be anything, might be deprecated
-  }
+    "InputFolder": "",
+    "OutputFile": "",
+    "Title": "Untitled",
+    "Link": "https://localhost:5500/index.xml",
+    "Description": "An RSS feed",
+    "Articles": null,
+    "Channel": {
+        "Author": "anonymous",
+        "Language": "",
+        "Copyright": "",
+        "ManagingEditor": "",
+        "WebMaster": "",
+        "Category": "",
+        "Generator": "",
+        "Docs": "",
+        "Cloud": "",
+        "Ttl": "",
+        "Image": "",
+        "Rating": "",
+        "SkipHours": "",
+        "SkipDays": ""
+    }
+}
 ```
 
 Note, the most recent update also allows users to specify their own config path, which you can define like so.

--- a/lib/args.go
+++ b/lib/args.go
@@ -1,34 +1,33 @@
 package lib
 
 import (
-  "errors"
-  "flag"
-  "os"
+	"errors"
+	"flag"
+	"os"
 )
 
 func getCommand(arguments []string) (string, error) {
-  validCommands := []string{"update", "ls", "conf"}
-  for _, validCommand := range validCommands {
-    for _, argument := range arguments {
-      if argument == validCommand {
-        return validCommand, nil
-      }
-    }
-  }
-  return "", errors.New("No valid command found. Use mdrss <<ls, update, conf>>")
+	validCommands := []string{"update", "ls", "conf", "init"}
+	for _, validCommand := range validCommands {
+		for _, argument := range arguments {
+			if argument == validCommand {
+				return validCommand, nil
+			}
+		}
+	}
+	return "", errors.New("No valid command found. Use mdrss <<ls, update, conf, init>>")
 }
 
-func defaultConfigPath() string {
-  dirname, _ := os.UserHomeDir()
-  return dirname + "/.mdrss/config.json"
+func DefaultConfigPath() string {
+	dirname, _ := os.UserHomeDir()
+	return dirname + "/.mdrss/config.json"
 }
 
 func ParseArguments(arguments []string) (map[string]*string, error) {
-  parsedArguments := make(map[string]*string)
-  command, commandErr := getCommand(arguments)
-  parsedArguments["config"] = flag.String("config", defaultConfigPath(), "path to config.json")
-  parsedArguments["command"] = &command
-  flag.Parse()
-  return parsedArguments, commandErr
+	parsedArguments := make(map[string]*string)
+	command, commandErr := getCommand(arguments)
+	parsedArguments["config"] = flag.String("config", DefaultConfigPath(), "path to config.json")
+	parsedArguments["command"] = &command
+	flag.Parse()
+	return parsedArguments, commandErr
 }
-

--- a/lib/config.go
+++ b/lib/config.go
@@ -23,5 +23,5 @@ func ReadConfig(configPath string) (Config, error) {
 		}
 		return config, nil
 	}
-	return config, errors.New("Config file not found. Please add it at ~/.mdrss/config.json")
+	return config, errors.New("Config file not found. Please add it at ~/.mdrss/config.json or run \"mdrss init\"")
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -7,22 +7,21 @@ import (
 )
 
 func FileExists(filename string) bool {
-  if _, err := os.Stat(filename); err != nil {
-    return false
-  }
-  return true
+	if _, err := os.Stat(filename); err != nil {
+		return false
+	}
+	return true
 }
 
 func ReadConfig(configPath string) (Config, error) {
-  var config Config
-  if FileExists(configPath) {
-    configContent, _ := os.ReadFile(configPath)
-    jsonErr := json.Unmarshal(configContent, &config)
-    if jsonErr != nil {
-      return config, errors.New("Error when reading config file.")
-    }
-    return config, nil
-  }
-  return config, errors.New("Config file not found. Please add it at ~/.mdrss/config.json")
+	var config Config
+	if FileExists(configPath) {
+		configContent, _ := os.ReadFile(configPath)
+		jsonCfgErr := json.Unmarshal(configContent, &config)
+		if jsonCfgErr != nil {
+			return config, errors.New("Error when reading config file.")
+		}
+		return config, nil
+	}
+	return config, errors.New("Config file not found. Please add it at ~/.mdrss/config.json")
 }
-

--- a/lib/rss.go
+++ b/lib/rss.go
@@ -1,51 +1,74 @@
 package lib
 
 import (
-  "time"
-  "os"
+	"os"
+	"time"
 )
 
 func addItem(xmlContent string, config Config, article Article) string {
-  timestamp := article.DatePublished.Format(time.RFC822Z)
-  xmlContent += "\t<item>\n"
-  xmlContent += "\t\t<title>" + article.Title + "</title>\n"
-  xmlContent += "\t\t<link>" + config.Link + "</link>\n"
-  xmlContent += "\t\t<pubDate>" + timestamp + "</pubDate>\n"
-  xmlContent += "\t\t<description><![CDATA[" + article.Description + "]]></description>\n"
-  xmlContent += "\t</item>\n"
-  return xmlContent
+	timestamp := article.DatePublished.Format(time.RFC822Z)
+	xmlContent += "\t<item>\n"
+	xmlContent += "\t\t"
+	xmlContent = fillChannel(xmlContent, "author", config.Channel.Author)
+	xmlContent += "\t\t<title>" + article.Title + "</title>\n"
+	xmlContent += "\t\t<link>" + config.Link + "</link>\n"
+	xmlContent += "\t\t<pubDate>" + timestamp + "</pubDate>\n"
+	xmlContent += "\t\t<description><![CDATA[" + article.Description + "]]></description>\n"
+	xmlContent += "\t</item>\n"
+	return xmlContent
 }
 
 func addHeader(config Config) string {
-  timestamp := time.Now().Format(time.RFC822Z)
-  xmlContent := "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
-  xmlContent += "<rss version=\"2.0\">\n"
-  xmlContent += "<channel>\n"
-  xmlContent += "<title>" + config.Description + "</title>\n"
-  xmlContent += "<author>" + config.Author + "</author>\n"
-  xmlContent += "<link>" + config.Link + "</link>\n"
-  xmlContent += "<lastBuildDate>" + timestamp + "</lastBuildDate>\n"
-  xmlContent += "<description>" + config.Description + "</description>\n"
-  return xmlContent
+	timestamp := time.Now().Format(time.RFC822Z)
+	xmlContent := "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+	xmlContent += "<rss version=\"2.0\">\n"
+	xmlContent += "<lastBuildDate>" + timestamp + "</lastBuildDate>\n"
+	xmlContent += "<channel>\n"
+	xmlContent += "<title>" + config.Description + "</title>\n"
+	xmlContent += "<link>" + config.Link + "</link>\n"
+	xmlContent += "<description>" + config.Description + "</description>\n"
+
+	xmlContent = fillChannel(xmlContent, "language", config.Channel.Language)
+	xmlContent = fillChannel(xmlContent, "copyright", config.Channel.Copyright)
+	xmlContent = fillChannel(xmlContent, "managingEditor", config.Channel.ManagingEditor)
+	xmlContent = fillChannel(xmlContent, "webMaster", config.Channel.WebMaster)
+	xmlContent = fillChannel(xmlContent, "category", config.Channel.Category)
+	xmlContent = fillChannel(xmlContent, "generator", config.Channel.Generator)
+	xmlContent = fillChannel(xmlContent, "docs", config.Channel.Docs)
+	xmlContent = fillChannel(xmlContent, "cloud", config.Channel.Cloud)
+	xmlContent = fillChannel(xmlContent, "ttl", config.Channel.Ttl)
+	// Copy image into same folder as feed so server can serve it
+	xmlContent = fillChannel(xmlContent, "image", config.Channel.Image)
+	xmlContent = fillChannel(xmlContent, "rating", config.Channel.Rating)
+	xmlContent = fillChannel(xmlContent, "skipHours", config.Channel.SkipHours)
+	xmlContent = fillChannel(xmlContent, "skipDays", config.Channel.SkipDays)
+
+	return xmlContent
+}
+
+func fillChannel(xmlContent, tag, value string) string {
+	if value != "" {
+		return xmlContent + "<" + tag + ">" + value + "</" + tag + ">\n"
+	}
+	return xmlContent
 }
 
 func CreateRSS(config Config) string {
-  xmlContent := addHeader(config)
-  for _, article := range config.Articles {
-    if len(article.Title) != 0 {
-      xmlContent = addItem(xmlContent, config, article)
-      Info.Printf("Added '%s' to RSS feed. ", article.Title)
-    } else {
-      Warn.Printf("%s doesn't have a valid markdown title.", article.Filename)
-    }
-  }
-  xmlContent += "</channel>\n</rss>\n"
-  return xmlContent 
+	xmlContent := addHeader(config)
+	for _, article := range config.Articles {
+		if len(article.Title) != 0 {
+			xmlContent = addItem(xmlContent, config, article)
+			Info.Printf("Added '%s' to RSS feed. ", article.Title)
+		} else {
+			Warn.Printf("%s doesn't have a valid markdown title.", article.Filename)
+		}
+	}
+	xmlContent += "</channel>\n</rss>\n"
+	return xmlContent
 }
 
 func WriteRSS(rssContent string, config Config) error {
-  rssByte := []byte(rssContent)
-  err := os.WriteFile(config.OutputFile, rssByte, 0644)
-  return err
+	rssByte := []byte(rssContent)
+	err := os.WriteFile(config.OutputFile, rssByte, 0644)
+	return err
 }
-

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,42 +1,62 @@
 package lib
 
 import (
-  "regexp"
-  "time"
+	"regexp"
+	"time"
 )
 
 type Markdown struct {
-  Content []Line
+	Content []Line
 }
 
 type Line struct {
-  Link *regexp.Regexp
-  UnorderedList *regexp.Regexp
-  OrderedList *regexp.Regexp
-  CodeBlock *regexp.Regexp
+	Link          *regexp.Regexp
+	UnorderedList *regexp.Regexp
+	OrderedList   *regexp.Regexp
+	CodeBlock     *regexp.Regexp
 
-  // optional fields
-  CodeBlockOpen bool
-  UnorderedListActive bool
-  OrderedListActive bool
+	// optional fields
+	CodeBlockOpen       bool
+	UnorderedListActive bool
+	OrderedListActive   bool
 }
 
 type Article struct {
-  Id int
-  Title string
-  Filename string
-  Description string
-  DatePublished time.Time
+	Id            int
+	Title         string
+	Author        string
+	Filename      string
+	Description   string
+	DatePublished time.Time
 }
 
 type Config struct {
-  Description string
-  InputFolder string
-  OutputFile string
-  Author string
-  Link string
+	InputFolder string
+	OutputFile  string
+	// Required for valid RSS
+	Title       string
+	Link        string
+	Description string
 
-  // optional fields
-  Articles []Article
+	// optional fields
+	Articles []Article
+	Channel  ChannelAttributes
 }
 
+type ChannelAttributes struct {
+	// https://www.rssboard.org/rss-specification
+	Author         string
+	Language       string
+	Copyright      string
+	ManagingEditor string
+	WebMaster      string
+	Category       string
+	Generator      string
+	Docs           string
+	Cloud          string
+	Ttl            string
+	Image          string
+	Rating         string
+	SkipHours      string
+	SkipDays       string
+}

--- a/mdrss.go
+++ b/mdrss.go
@@ -1,73 +1,127 @@
 package main
 
 import (
-  mdrss "github.com/TimoKats/mdrss/lib"
-  "reflect"
-  "errors"
-  "os"
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	mdrss "github.com/TimoKats/mdrss/lib"
 )
 
 func lsCommand(config mdrss.Config) error {
-  files, fileErr := mdrss.GetArticles(config)
-  if fileErr == nil {
-    for _, file := range files {
-      mdrss.Info.Println(file)
-    }
-  }
-  return fileErr
+	files, fileErr := mdrss.GetArticles(config)
+	if fileErr == nil {
+		for _, file := range files {
+			mdrss.Info.Println(file)
+		}
+	}
+	return fileErr
 }
 
 func updateCommand(config mdrss.Config) error {
-  files, fileErr := mdrss.GetArticles(config)
-  if fileErr == nil {
-    config.Articles = mdrss.ReadMarkdown(config, files)
-    rssXml := mdrss.CreateRSS(config)
-    rssErr := mdrss.WriteRSS(rssXml, config)
-    if rssErr != nil {
-      return rssErr
-    }
-    mdrss.Info.Printf("Content written to %s", config.OutputFile)
-  }
-  return fileErr
+	files, fileErr := mdrss.GetArticles(config)
+	if fileErr == nil {
+		config.Articles = mdrss.ReadMarkdown(config, files)
+		rssXml := mdrss.CreateRSS(config)
+		rssErr := mdrss.WriteRSS(rssXml, config)
+		if rssErr != nil {
+			return rssErr
+		}
+		mdrss.Info.Printf("Content written to %s", config.OutputFile)
+	}
+	return fileErr
 }
 
 func confCommand(config mdrss.Config) error {
 	configValues := reflect.ValueOf(config)
-  typeOfS := configValues.Type()
-  for i := 0; i < configValues.NumField(); i++ {
-    if len(typeOfS.Field(i).Name) < 8 {
-      mdrss.Info.Printf("%s\t\t%v\n", typeOfS.Field(i).Name, configValues.Field(i).Interface())
-    } else {
-      mdrss.Info.Printf("%s\t%v\n", typeOfS.Field(i).Name, configValues.Field(i).Interface())
-    }
-  }
-  return nil
+	typeOfS := configValues.Type()
+	for i := 0; i < configValues.NumField(); i++ {
+		if len(typeOfS.Field(i).Name) < 8 {
+			mdrss.Info.Printf("%s\t\t%v\n", typeOfS.Field(i).Name, configValues.Field(i).Interface())
+		} else {
+			mdrss.Info.Printf("%s\t%v\n", typeOfS.Field(i).Name, configValues.Field(i).Interface())
+		}
+	}
+	return nil
+}
+
+func promptUsr(prompt string, attrubute *string, fallback string) {
+	fmt.Print("\033[33m?\033[0m " + prompt + " \033[37;2m(" + fallback + ") > \033[0m")
+	var input string
+	in := bufio.NewReader(os.Stdin)
+	input, err := in.ReadString('\n')
+	input = strings.Replace(input, "\n", "", -1)
+	if input == "" || err != nil {
+		*attrubute = fallback
+		return
+	}
+	*attrubute = input
+}
+
+func initCommand() error {
+	configPath := mdrss.DefaultConfigPath()
+	var newConfig mdrss.Config
+	promptUsr("Feed title", &newConfig.Title, "Untitled")
+	promptUsr("Feed link", &newConfig.Link, "https://localhost:5500/index.xml")
+	promptUsr("Feed description", &newConfig.Description, "An RSS feed")
+	promptUsr("Feed author", &newConfig.Channel.Author, "anonymous")
+	defaultDir, _ := os.Getwd()
+	promptUsr("Input folder path", &newConfig.InputFolder, defaultDir+"/test/")
+	promptUsr("Output file path", &newConfig.OutputFile, defaultDir+"/index.xml")
+
+	// Only update file after ALL init fields are inputted
+	dirCreateErr := os.MkdirAll(filepath.Dir(configPath), 0755)
+	configFile, fileCreateErr := os.Create(configPath)
+	if fileCreateErr != nil {
+		if dirCreateErr != nil {
+			mdrss.Error.Println("unable to create configuration directory")
+		} else {
+			mdrss.Error.Println("unable to create configuration file")
+		}
+		return nil
+	}
+
+	out, jsonErr := json.MarshalIndent(newConfig, "", "    ")
+	if jsonErr != nil {
+		mdrss.Error.Println("Critical failure in initialization of config")
+	}
+	configFile.Write(out)
+	fmt.Println("\033[32m MDRSS Initialized! Run \"mdrss update\" to update your feed!")
+	return nil
 }
 
 func parseCommand(command string, config mdrss.Config) error {
-  switch (command) {
-    case "ls":
-      return lsCommand(config)
-    case "conf":
-      return confCommand(config)
-    case "update":
-      return updateCommand(config)
-    default:
-      return errors.New("Command not found.")
-  }
+	switch command {
+	case "ls":
+		return lsCommand(config)
+	case "conf":
+		return confCommand(config)
+	case "update":
+		return updateCommand(config)
+	default:
+		return errors.New("Command not found.")
+	}
 }
 
 func main() {
-  arguments, argumentErr := mdrss.ParseArguments(os.Args)
-  config, configErr := mdrss.ReadConfig(*arguments["config"])
-  mdrss.Info.Printf("Using config location: %v", *arguments["config"])
-  if err := errors.Join(argumentErr, configErr); err != nil {
-     mdrss.Error.Println(err)
-     return
-   }
-  commandErr := parseCommand(*arguments["command"], config)
-  if commandErr != nil {
-    mdrss.Error.Println(commandErr)
-  }
+	arguments, argumentErr := mdrss.ParseArguments(os.Args)
+	if *arguments["command"] == "init" {
+		initCommand()
+		return
+	}
+	config, configErr := mdrss.ReadConfig(*arguments["config"])
+	mdrss.Info.Printf("Using config location: %v", *arguments["config"])
+	if err := errors.Join(argumentErr, configErr); err != nil {
+		mdrss.Error.Println(err)
+		return
+	}
+	commandErr := parseCommand(*arguments["command"], config)
+	if commandErr != nil {
+		mdrss.Error.Println(commandErr)
+	}
 }
-

--- a/mdrss.go
+++ b/mdrss.go
@@ -64,12 +64,13 @@ func promptUsr(prompt string, attrubute *string, fallback string) {
 }
 
 func initCommand() error {
-	configPath := mdrss.DefaultConfigPath()
+	var configPath string
 	var newConfig mdrss.Config
 	promptUsr("Feed title", &newConfig.Title, "Untitled")
 	promptUsr("Feed link", &newConfig.Link, "https://localhost:5500/index.xml")
 	promptUsr("Feed description", &newConfig.Description, "An RSS feed")
 	promptUsr("Feed author", &newConfig.Channel.Author, "anonymous")
+	promptUsr("Config path", &configPath, mdrss.DefaultConfigPath())
 	defaultDir, _ := os.Getwd()
 	promptUsr("Input folder path", &newConfig.InputFolder, defaultDir+"/test/")
 	promptUsr("Output file path", &newConfig.OutputFile, defaultDir+"/index.xml")

--- a/mdrss.go
+++ b/mdrss.go
@@ -55,7 +55,7 @@ func promptUsr(prompt string, attrubute *string, fallback string) {
 	var input string
 	in := bufio.NewReader(os.Stdin)
 	input, err := in.ReadString('\n')
-	input = strings.Replace(input, "\n", "", -1)
+	input = strings.TrimSpace(input)
 	if input == "" || err != nil {
 		*attrubute = fallback
 		return
@@ -90,9 +90,9 @@ func initCommand() error {
 	if jsonErr != nil {
 		mdrss.Error.Println("Critical failure in initialization of config")
 	}
-	configFile.Write(out)
+	_, writeErr := configFile.Write(out)
 	fmt.Println("\033[32m MDRSS Initialized! Run \"mdrss update\" to update your feed!")
-	return nil
+	return writeErr
 }
 
 func parseCommand(command string, config mdrss.Config) error {
@@ -111,7 +111,10 @@ func parseCommand(command string, config mdrss.Config) error {
 func main() {
 	arguments, argumentErr := mdrss.ParseArguments(os.Args)
 	if *arguments["command"] == "init" {
-		initCommand()
+		initErr := initCommand()
+		if initErr != nil {
+			mdrss.Error.Println(initErr)
+		}
 		return
 	}
 	config, configErr := mdrss.ReadConfig(*arguments["config"])

--- a/mdrss_test.go
+++ b/mdrss_test.go
@@ -1,92 +1,92 @@
 package main
 
 import (
-  mdrss "github.com/TimoKats/mdrss/lib"
-  "os/exec"
-  "testing"
+	"os/exec"
+	"testing"
+
+	mdrss "github.com/TimoKats/mdrss/lib"
 )
 
 func testConfig() mdrss.Config {
-  var config mdrss.Config
-  config.Description = "Testing weblog"
-  config.InputFolder = "test/"
-  config.OutputFile = "rss.xml"
-  config.Author = "Testing Test"
-  config.Link = "test@testing.com"
-  return config
+	var config mdrss.Config
+	config.Description = "Testing weblog"
+	config.InputFolder = "test/"
+	config.OutputFile = "rss.xml"
+	config.Channel.Author = "Testing Test"
+	config.Link = "test@testing.com"
+	return config
 }
 
 func TestFileExists(t *testing.T) {
-  got := mdrss.FileExists("mdrss.go")
-  want := true
-  if got != want {
-    t.Errorf("got %v, wanted %v", got, want)
-  }
+	got := mdrss.FileExists("mdrss.go")
+	want := true
+	if got != want {
+		t.Errorf("got %v, wanted %v", got, want)
+	}
 }
 
 func TestGetArticles(t *testing.T) {
-  config := testConfig()
-  articles, _ := mdrss.GetArticles(config)
-  got := []string{}
-  want := []string{"another-article.md"}
-  for _, article := range articles {
-    got = append(got, article.Filename)
-  }
-  if len(got) != len(want) {
-    t.Errorf("got %v, wanted %v", got, want)
-  }
+	config := testConfig()
+	articles, _ := mdrss.GetArticles(config)
+	got := []string{}
+	want := []string{"another-article.md"}
+	for _, article := range articles {
+		got = append(got, article.Filename)
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %v, wanted %v", got, want)
+	}
 }
 
 func TestCreateMarkdown(t *testing.T) {
-  config := testConfig()
-  files, _ := mdrss.GetArticles(config)
-  config.Articles = mdrss.ReadMarkdown(config, files)
-  got := config.Articles[0].Title
-  want := "This article has a title." 
-  if got != want {
-    t.Errorf("got %v, wanted %v", got, want)
-  }
+	config := testConfig()
+	files, _ := mdrss.GetArticles(config)
+	config.Articles = mdrss.ReadMarkdown(config, files)
+	got := config.Articles[0].Title
+	want := "This article has a title."
+	if got != want {
+		t.Errorf("got %v, wanted %v", got, want)
+	}
 }
 
 func TestConvertLists(t *testing.T) {
-  want := "<ul><li>text</li>"
-  got := mdrss.ConvertMarkdownToRSS("  - text")
-  if got != want {
-    t.Errorf("got %v, wanted %v", got, want)
-  }
+	want := "<ul><li>text</li>"
+	got := mdrss.ConvertMarkdownToRSS("  - text")
+	if got != want {
+		t.Errorf("got %v, wanted %v", got, want)
+	}
 }
 
 func TestConvertLinks(t *testing.T) {
-  want := "<p>Click here for the <a href='https://timokats.xyz'>link</a></p>"
-  got := mdrss.ConvertMarkdownToRSS("Click here for the [link](https://timokats.xyz)")
-  if got != want {
-    t.Errorf("got %v, wanted %v", got, want)
-  }
+	want := "<p>Click here for the <a href='https://timokats.xyz'>link</a></p>"
+	got := mdrss.ConvertMarkdownToRSS("Click here for the [link](https://timokats.xyz)")
+	if got != want {
+		t.Errorf("got %v, wanted %v", got, want)
+	}
 }
 
 func TestFakeEnclosures(t *testing.T) {
-  _, fileSizeErr := mdrss.FileSizeUrl("hello.mp3")
-  if fileSizeErr == nil {
-    t.Errorf("Should give Error, but no.")
-  }
+	_, fileSizeErr := mdrss.FileSizeUrl("hello.mp3")
+	if fileSizeErr == nil {
+		t.Errorf("Should give Error, but no.")
+	}
 }
 
 func TestBasics(t *testing.T) {
-  config := testConfig()
-  articles, _ := mdrss.GetArticles(config)
-  config.Articles = mdrss.ReadMarkdown(config, articles)
-  rssXml := mdrss.CreateRSS(config)
-  rssErr := mdrss.WriteRSS(rssXml, config)
-  got := mdrss.FileExists("rss.xml")
-  want := true
-  if got != want || rssErr != nil {
-    t.Errorf("got %v, wanted %v", got, want)
-  } else {
-    cmd := exec.Command("rm", "rss.xml")
-    runErr := cmd.Run()
-    if runErr != nil {
-      mdrss.Error.Println(runErr)
-    }
-  }
+	config := testConfig()
+	articles, _ := mdrss.GetArticles(config)
+	config.Articles = mdrss.ReadMarkdown(config, articles)
+	rssXml := mdrss.CreateRSS(config)
+	rssErr := mdrss.WriteRSS(rssXml, config)
+	got := mdrss.FileExists("rss.xml")
+	want := true
+	if got != want || rssErr != nil {
+		t.Errorf("got %v, wanted %v", got, want)
+	} else {
+		cmd := exec.Command("rm", "rss.xml")
+		runErr := cmd.Run()
+		if runErr != nil {
+			mdrss.Error.Println(runErr)
+		}
+	}
 }
-


### PR DESCRIPTION
Reading the RSS 2.0 Spec for this project, I realized how many optional elements are allowed, and I wanted to extend that customizability to the user, so I added/moved around some of the config struct to accommodate for this.

Conversely, I absolutely love programs that make set-up fast, easy, and simple, so I have committed an interactive prompt that takes the user through a series of 6 required questions to get right into converting, while simultaneously creating the config file if it wasn't there already, and scaffolding for all the extensible options from above (with `json.Marshal`)
![image](https://github.com/user-attachments/assets/30e32d07-e257-4a44-8f2a-a79dc5c50347)
![image](https://github.com/user-attachments/assets/58b59557-7a26-4812-abe6-443e6588d517)
I just thought this would be nice to provide to possibly less-experienced Linux users who want to use the project 😄 